### PR TITLE
Build for android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ out/
 /jni/cmake-build-*/
 /jni/venv
 *.log
+ndk

--- a/arch-detect/build.gradle.kts
+++ b/arch-detect/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.bundling.Zip
+import org.gradle.api.file.RelativePath
+
 plugins {
     id("tel.schich.libdatachannel.convention.common")
 }
@@ -8,22 +11,76 @@ val nativeLibs by configurations.registering
 
 dependencies {
     api(rootProject)
-    nativeLibs(project(mapOf("path" to rootProject.path, "configuration" to "archDetectConfiguration")))
+    nativeLibs(project(mapOf(
+        "path" to rootProject.path,
+        "configuration" to "archDetectConfiguration"
+    )))
 }
 
 tasks.jar.configure {
     dependsOn(nativeLibs)
-    for (jar in nativeLibs.get().resolvedConfiguration.resolvedArtifacts) {
-        val classifier = jar.classifier ?: continue
-        from(zipTree(jar.file)) {
-            include("native/*.so")
-            include("native/*.dll")
-            into(classifier)
+    for (artifact in nativeLibs.get().resolvedConfiguration.resolvedArtifacts) {
+        val classifier = artifact.classifier ?: continue
+        if (!classifier.startsWith("android-")) {
+            val classifier = artifact.classifier ?: continue
+            from(zipTree(artifact.file)) {
+                include("native/*.so")
+                include("native/*.dll")
+                into(classifier)
+            }
         }
     }
 }
 
+val androidAar by tasks.registering(Zip::class) {
+    group = "build"
+    archiveBaseName.set(project.name+"-android")
+    archiveExtension.set("aar")
+    destinationDirectory.set(layout.buildDirectory.dir("outputs/aar"))
+    val manifestFile = layout.buildDirectory.file("tmp/androidAar/AndroidManifest.xml")    
+    doFirst {
+        val mf = manifestFile.get().asFile
+        mf.parentFile.mkdirs()
+        mf.writeText(
+            """
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                package="${project.group}.libdatachannel.archdetect">
+            </manifest>
+            """.trimIndent()
+        )
+    }    
+    from(manifestFile) {
+        into("") 
+    }
+    dependsOn(nativeLibs, tasks.jar)
+}
+
+androidAar.configure {
+    nativeLibs.get().resolvedConfiguration.resolvedArtifacts.forEach { artifact ->
+        val classifier = artifact.classifier ?: return@forEach        
+        if (classifier.startsWith("android-")) {
+            var abi = classifier.removePrefix("android-")            
+            from(zipTree(artifact.file)) {
+                include("native/*.so")
+                includeEmptyDirs = false            
+                eachFile {
+                    val p = path
+                    val newPath = RelativePath(true, "jni", abi, p.removePrefix("native/"))
+                    relativePath = newPath
+                }
+            }
+        }
+    }
+}
+
+tasks.jar {
+    finalizedBy(androidAar)
+}
+
 publishing.publications.withType<MavenPublication>().configureEach {
+    artifact(androidAar) {
+        classifier = "android"
+    }
     pom {
         description = "${rootProject.description} The ${project.name} module bundles all architectures and allows runtime architecture detection."
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,21 +161,16 @@ val targets = listOf(
     BuildTarget(image = "linux-x86", classifier = "x86_32"),
     BuildTarget(image = "linux-arm64", classifier = "aarch64"),
     BuildTarget(image = "windows-static-x64", classifier = "windows-x86_64"),
-    BuildTarget(image = "windows-static-x86", classifier = "windows-x86_32"),
-    BuildTarget(
-        image = "android-arm", 
-        classifier = "android-armeabi-v7a",
-        args = listOf("-DANDROID_ABI=armeabi-v7a", "-DANDROID_PLATFORM=android-21"),
-    ),
+    // BuildTarget(image = "windows-static-x86", classifier = "windows-x86_32"),
+    // BuildTarget(
+    //     image = "android-arm", 
+    //     classifier = "android-armeabi-v7a",
+    //     args = listOf("-DANDROID_ABI=armeabi-v7a", "-DANDROID_PLATFORM=android-21"),
+    // ),
     BuildTarget(
         image = "android-arm64", 
         classifier = "android-arm64-v8a",
         args = listOf("-DANDROID_ABI=arm64-v8a", "-DANDROID_PLATFORM=android-21"),
-    ),
-    BuildTarget(
-        image = "android-x86", 
-        classifier = "android-x86",
-        args = listOf("-DANDROID_ABI=x86", "-DANDROID_PLATFORM=android-21"),
     ),
     BuildTarget(
         image = "android-x86_64", 

--- a/src/main/java/tel/schich/libdatachannel/Platform.java
+++ b/src/main/java/tel/schich/libdatachannel/Platform.java
@@ -30,8 +30,21 @@ class Platform {
         return System.getProperty("os.name").toLowerCase().contains("win");
     }
 
+    public static boolean isAndroid() {
+        try {
+            return System.getProperty("java.specification.vendor").contains("Android") ||
+                   System.getProperty("java.vendor").contains("Android") ||
+                   System.getProperty("java.vm.vendor").contains("Android");
+        } catch (SecurityException e) {
+            return System.getProperty("java.vm.name").toLowerCase().contains("dalvik") ||
+                   System.getProperty("java.vm.name").toLowerCase().contains("art");
+        }
+    }
+
     public static OS getOS() {
-        if (isLinux()) {
+        if(isAndroid()){
+            return OS.ANDROID;
+        } else if (isLinux()) {
             return OS.LINUX;
         } else if (isWindows()) {
             return OS.WINDOWS;
@@ -57,6 +70,9 @@ class Platform {
     private static String archPrefixForOs() {
         if (getOS() == OS.WINDOWS) {
             return "windows-";
+        }
+        if (getOS() == OS.ANDROID){
+            return "android-";
         }
         return "";
     }
@@ -143,6 +159,7 @@ class Platform {
     public enum OS {
         LINUX,
         WINDOWS,
-        UNKNOWN
+        UNKNOWN,
+        ANDROID
     }
 }


### PR DESCRIPTION
Initial work to get the library built for android.

Android has its own native loader and needs native libraries packaged into a specific path in an aar file for auto selection.

I made some changes to the `arch-detect` build file to do that, but the aar file needs to be included manually with
```
    implementation 'tel.schich:libdatachannel-java-arch-detect:VERSION:android@aar'
```
i am not sure if there is a better way.

This is a draft because the library doesn't not work yet, it loads but crashes due to libssl not being found
` java.lang.UnsatisfiedLinkError: dlopen failed: library "libssl.so.3" not found: needed  `
i am looking into getting it statically linked.
